### PR TITLE
Write byte directly without casting to byte slice

### DIFF
--- a/countbits/go/countbits.go
+++ b/countbits/go/countbits.go
@@ -75,11 +75,7 @@ func main() {
 			c += byte((j & b[i]) >> i)
 		}
 
-		// https://stackoverflow.com/questions/16888357/convert-an-integer-to-a-byte-array
-		//bs := make([]byte, 4)
-		//binary.LittleEndian.PutUint32(bs, 31415926)
-
-		_, err := w.Write([]byte{c})
+		err := w.WriteByte(c)
 		if err != nil {
 			panic(err)
 		}


### PR DESCRIPTION
countbits in go, avoid casting the byte to a byte slice before writing to save ~30%

```console
$ go build -o main countbits.go
$ git checkout countbits-go-avoid-cast-to-write-byte
Switched to branch 'countbits-go-avoid-cast-to-write-byte'
$ go build -o avoid countbits.go

$ time ./main && mv counts.bin main.counts.bin
{"-10000000":4832,"-100000000":1671,"-110000000":1324,"-120000000":977,"-130000000":630,"-140000000":282,"-20000000":4479,"-30000000":4121,"-40000000":3765,"-50000000":3416,"-60000000":3067,"-70000000":2714,"-80000000":2366,"-90000000":2018,"0":5202,"10000000":5550,"100000000":8749,"110000000":9099,"120000000":9452,"130000000":9805,"140000000":10158,"20000000":5916,"30000000":6266,"40000000":6618,"50000000":6984,"60000000":7335,"70000000":7693,"80000000":8046,"90000000":8397,"array":0,"average":358,"end":10419,"file":10,"start":0}

real	0m10.431s
user	0m10.116s
sys	0m0.504s

$ time ./avoid && mv counts.bin avoid.counts.bin
{"-10000000":3198,"-100000000":1143,"-110000000":913,"-120000000":670,"-130000000":430,"-140000000":187,"-20000000":2970,"-30000000":2740,"-40000000":2512,"-50000000":2281,"-60000000":2053,"-70000000":1823,"-80000000":1597,"-90000000":1369,"0":3427,"10000000":3655,"100000000":5743,"110000000":5972,"120000000":6201,"130000000":6429,"140000000":6657,"20000000":3884,"30000000":4113,"40000000":4342,"50000000":4571,"60000000":4818,"70000000":5058,"80000000":5286,"90000000":5514,"array":0,"average":235,"end":6829,"file":0,"start":0}

real	0m6.961s
user	0m6.402s
sys	0m0.411s

$ shasum *counts.bin
2c9fe1b2030c64112701d0e049671b61aa8c42bc  avoid.counts.bin
2c9fe1b2030c64112701d0e049671b61aa8c42bc  main.counts.bin
```