### PR TITLE
Node countbits, Drain the WriteStream to avoid blowing the heap

### DIFF
--- a/countbits/javascript_1/countbits.js
+++ b/countbits/javascript_1/countbits.js
@@ -18,42 +18,46 @@ function elapsedMs() {
     return Math.floor((diff[0] * MS_PER_SEC) + (diff[1] / NS_PER_MS));
 }
 
-let times = { "start": elapsedMs() };
+(async() => {
+  let times = { "start": elapsedMs() };
 
-let b = [];
-for (let i = 0; i < MAXBITS; i++) { b[i] = 1 << i; }
+  let b = [];
+  for (let i = 0; i < MAXBITS; i++) { b[i] = 1 << i; }
 
-times["array"] = elapsedMs();
+  times["array"] = elapsedMs();
 
-let f = fs.createWriteStream("counts.bin")
+  let f = fs.createWriteStream("counts.bin")
 
-times["file"] = elapsedMs();
+  times["file"] = elapsedMs();
 
-const buf = Buffer.allocUnsafe(1);
-let c;
-for (let j = BOT; j < TOP; j++)
-{
+  const buf = Buffer.allocUnsafe(1);
+  let c;
+  for (let j = BOT; j < TOP; j++)
+  {
     if ((j % 10000000) == 0) { times[j] = elapsedMs(); }
     c = (j < 0 ? 1 : 0);
     for (let i = 0; i < MAXBITS; i++)
-     { c += ((j & b[i]) >> i); }
+    { c += ((j & b[i]) >> i); }
 
     // FIXME: I am uncertain if this will actually write the correct data
     //  is the write async such that it might use the buffer's contents
     //  later on, after the buffer has been updated again?
     buf.writeUInt8(c, 0);
-    f.write(buf);
-}
+    if (!f.write(buf)) {
+      // wait for the drain event that will clear the WriteStream buffer
+      await new Promise(resolve => f.once('drain', resolve));
+    }
+  }
 
-// last positive int is for sure MAXBITS on bits
-//  we have to do this out of loop or else int rolls around and becomes infinite loop!
-buf.writeUInt8(MAXBITS, 0);
-f.write(buf);
+  // last positive int is for sure MAXBITS on bits
+  //  we have to do this out of loop or else int rolls around and becomes infinite loop!
+  buf.writeUInt8(MAXBITS, 0);
+  f.write(buf);
 
-f.end();
-times["end"] = elapsedMs();
+  f.end();
+  times["end"] = elapsedMs();
 
-times["average"] = Math.floor((times["end"] - times["file"]) / (Object.keys(times).length - 4));
+  times["average"] = Math.floor((times["end"] - times["file"]) / (Object.keys(times).length - 4));
 
-console.log(JSON.stringify(times));
-
+  console.log(JSON.stringify(times));
+})();


### PR DESCRIPTION
WriteStreams will buffer all writes until the stream is closed or the `drain` event is allowed to take the execution thread.

This fixes the OOM locally for me, but it takes a terribly long time (seemingly spending >75% of the time on I/O)